### PR TITLE
Configuration changes and updates of "Ignored" annotations

### DIFF
--- a/basic/pom-wildfly-client.xml
+++ b/basic/pom-wildfly-client.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <version.arquillian>1.7.0.Alpha14</version.arquillian>
-        <version.byteman>4.0.20</version.byteman>
+        <version.byteman>4.0.21</version.byteman>
         <version.jakartaee-api>10.0.0</version.jakartaee-api>
         <version.junit>4.13.2</version.junit>
         <version.reload4j>1.2.25</version.reload4j>

--- a/basic/pom.xml
+++ b/basic/pom.xml
@@ -412,6 +412,28 @@
             </build>
         </profile>
 
+        <!-- tests are skipped in default execution of surefire, because by default 2 specific executions are run (see "no-basic-module-only" profile) -->
+        <!-- this profile allows to run tests default execution -->
+        <profile>
+            <id>basic-module-only</id>
+            <activation>
+                <property>
+                    <name>specificModule</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <skip>false</skip>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <id>debugServer</id>
             <properties>

--- a/basic/src/test/java/org/wildfly/ejbclient/testsuite/integration/basic/addressbinding/SetSourceIpAddressTestCase.java
+++ b/basic/src/test/java/org/wildfly/ejbclient/testsuite/integration/basic/addressbinding/SetSourceIpAddressTestCase.java
@@ -113,7 +113,7 @@ public class SetSourceIpAddressTestCase {
 
     @Test
     @InSequence(10)
-    @Ignore //FIXME
+    @Ignore("https://issues.redhat.com/browse/WFLY-18273")
     public void testHostAndPortBindingInContainer() throws Exception {
         try (InitialContextDirectory ctx = new InitialContextDirectory.Supplier().get()) {
             EJBClientRemote ejbClientRemote = ctx.lookupStateful(CLIENT_ARCHIVE_NAME, EJBClient.class, EJBClientRemote.class);
@@ -142,7 +142,7 @@ public class SetSourceIpAddressTestCase {
 
     @Test
     @InSequence(20)
-    @Ignore //FIXME
+    @Ignore("https://issues.redhat.com/browse/WFLY-18273")
     public void testHostBindingInContainer() throws Exception {
         try (InitialContextDirectory ctx = new InitialContextDirectory.Supplier().get()) {
             EJBClientRemote ejbClientRemote = ctx.lookupStateful(CLIENT_ARCHIVE_NAME, EJBClient.class, EJBClientRemote.class);

--- a/multinode/pom-wildfly-client.xml
+++ b/multinode/pom-wildfly-client.xml
@@ -20,6 +20,7 @@
         <version.arquillian-container>5.0.0.Alpha6</version.arquillian-container>
         <version.creaper>2.0.2</version.creaper>
         <version.jakartaee-api>10.0.0</version.jakartaee-api>
+        <version.jboss-ejb3-ext-api>2.3.0.Final</version.jboss-ejb3-ext-api>
         <version.junit>4.13.2</version.junit>
         <version.reload4j>1.2.25</version.reload4j>
 


### PR DESCRIPTION
* shaded jar pom
  * increase the version of byteman in pom used for shaded jar as well (like [this commit](https://github.com/wildfly/ejb-client-testsuite/commit/29d2a049940bb08ba89cdca760e6eba7969520cd))
  * Add missing version.jboss-ejb3-ext-api version
* Allow to run the tests with specificModule system property as well (non-default run)
*  Add https://issues.redhat.com/browse/WFLY-18273 link to the comments