### PR TITLE
Fail mvn process if there is any test errors

### DIFF
--- a/multinode/pom-wildfly-client.xml
+++ b/multinode/pom-wildfly-client.xml
@@ -13,7 +13,6 @@
     <properties>
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
-        <maven.test.failure.ignore>true</maven.test.failure.ignore>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <version.arquillian>1.7.0.Alpha14</version.arquillian>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
         <version.wf.core>20.0.0.Final</version.wf.core>
 
         <!-- MULTINODE -->
-        <maven.test.failure.ignore>true</maven.test.failure.ignore>
         <version.arquillian.protocol>1.7.0.Alpha11</version.arquillian.protocol>
         <version.creaper>2.0.2</version.creaper>
 


### PR DESCRIPTION
I believe that such settings (`maven.test.failure.ignore`) should be configured in CI configuration (by `-Dmaven.test.failure.ignore=true` property) if necessary. But should not be configured directly in pom files.

My understanding is that `multinode/pom-wildfly-client.xml` is not used in upstream CI. But if pom.xml changes would cause any troubles for upstream CI, I can update QE CI and override this value there, but I believe that clearer way is to clear it from pom files directly.