### PR TITLE
Remove @Ignore annotation from bom test

### DIFF
--- a/basic/src/test/java/org/wildfly/ejbclient/testsuite/integration/basic/maven/MavenDependencyTestCase.java
+++ b/basic/src/test/java/org/wildfly/ejbclient/testsuite/integration/basic/maven/MavenDependencyTestCase.java
@@ -48,8 +48,6 @@ import static java.util.stream.Collectors.toList;
  */
 @RunWith(JUnit4.class)
 @RunAsClient
-//FIXME
-@Ignore
 public class MavenDependencyTestCase {
 
     private static Logger logger = Logger.getLogger(MavenDependencyTestCase.class.getName());


### PR DESCRIPTION
Remove @Ignore annotation from bom test. Test is explicitly ignored if jboss-client.jar is used (see [pom file here](https://github.com/wildfly/ejb-client-testsuite/blob/main/basic/pom-wildfly-client.xml#L394)). Test is working if default profile is used (most likely because bom building was added [here](https://github.com/wildfly/ejb-client-testsuite/commit/714a23a81b9beef49d0b45860b9cc3b346049db2#diff-ed47f8b6c4c6ca5f9ec0c411fb9806e5706bdaf74fc7226e9e31f40617125d83R64). Feel free to ping me and I can share a link to CI runs.