### PR TITLE
Fix bom usage

### DIFF
--- a/basic/pom-wildfly-client/pom.xml
+++ b/basic/pom-wildfly-client/pom.xml
@@ -16,6 +16,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <version.arquillian>1.9.1.Final</version.arquillian>
+        <version.arquillian.jakarta>10.0.0.Final</version.arquillian.jakarta>
+        <version.shrinkwrap>1.2.6</version.shrinkwrap>
+
         <version.byteman>4.0.21</version.byteman>
         <version.jakartaee-api>10.0.0</version.jakartaee-api>
         <version.junit>4.13.2</version.junit>
@@ -69,6 +72,20 @@
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
                 <version>${version.arquillian}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian.jakarta</groupId>
+                <artifactId>arquillian-jakarta-bom</artifactId>
+                <version>${version.arquillian.jakarta}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-bom</artifactId>
+                <version>${version.shrinkwrap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/basic/pom.xml
+++ b/basic/pom.xml
@@ -55,6 +55,20 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian.jakarta</groupId>
+                <artifactId>arquillian-jakarta-bom</artifactId>
+                <version>${version.arquillian.jakarta}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-bom</artifactId>
+                <version>${version.shrinkwrap}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>

--- a/multinode/pom-wildfly-client/pom.xml
+++ b/multinode/pom-wildfly-client/pom.xml
@@ -15,8 +15,11 @@
         <maven.compiler.source>11</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <version.arquillian>1.9.0.Final</version.arquillian>
-        <version.arquillian-container>5.1.0.Beta3</version.arquillian-container>
+        <version.arquillian>1.9.1.Final</version.arquillian>
+        <version.arquillian.jakarta>10.0.0.Final</version.arquillian.jakarta>
+        <version.shrinkwrap>1.2.6</version.shrinkwrap>
+
+        <version.arquillian-container>5.1.0.Beta4</version.arquillian-container>
         <version.creaper>2.0.2</version.creaper>
         <version.jakartaee-api>10.0.0</version.jakartaee-api>
         <version.jboss-ejb3-ext-api>2.4.0.Final</version.jboss-ejb3-ext-api>
@@ -32,7 +35,7 @@
         <version.plugin.jacoco>0.8.12</version.plugin.jacoco>
         <version.plugin.jar>3.3.0</version.plugin.jar>
         <version.plugin.surefire>3.0.0</version.plugin.surefire>
-        <version.wf.core>24.0.1.Final</version.wf.core>
+        <version.wf.core>25.0.0.Final</version.wf.core>
 
 
         <!-- Path to server zip archive, has to be specified at command line -->
@@ -399,6 +402,20 @@
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
                 <version>${version.arquillian}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian.jakarta</groupId>
+                <artifactId>arquillian-jakarta-bom</artifactId>
+                <version>${version.arquillian.jakarta}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-bom</artifactId>
+                <version>${version.shrinkwrap}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/multinode/pom.xml
+++ b/multinode/pom.xml
@@ -193,6 +193,20 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian.jakarta</groupId>
+                <artifactId>arquillian-jakarta-bom</artifactId>
+                <version>${version.arquillian.jakarta}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-bom</artifactId>
+                <version>${version.shrinkwrap}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,9 @@
         <version.ejb.client.bom>EJB-CLIENT-TESTSUITE</version.ejb.client.bom>
 
         <version.arquillian>1.9.1.Final</version.arquillian>
+        <version.arquillian.jakarta>10.0.0.Final</version.arquillian.jakarta>
+        <version.shrinkwrap>1.2.6</version.shrinkwrap>
+
         <version.jakartaee-api>10.0.0</version.jakartaee-api>
         <version.junit>4.13.2</version.junit>
         <version.reload4j>1.2.25</version.reload4j>

--- a/timers/pom.xml
+++ b/timers/pom.xml
@@ -62,6 +62,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-bom</artifactId>
+                <version>${version.shrinkwrap}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
* Tracker: https://github.com/wildfly/ejb-client-testsuite/issues/60
  * Please let me know if we should use another tracker for MRs here 
* Arquillian jakarta artifacts was moved to separate bom file, see the details on https://issues.redhat.com/browse/ARQ-2236
* ShrinkWrap has been removed from arquillian bom as a part of https://issues.redhat.com/browse/ARQ-2235
* This MR uses separate boms for the artifacts that have been removed from arquillian bom.
* This MR also updates multinode module, so it incorporates those MRs from dependabot:
  * https://github.com/wildfly/ejb-client-testsuite/pull/57
  *  https://github.com/wildfly/ejb-client-testsuite/pull/54
  *  https://github.com/wildfly/ejb-client-testsuite/pull/52

