### PR TITLE
Improve CI testing

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,5 @@
 # This workflow will build a Java project with Maven
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
 
 name: EJB Test Suite
 
@@ -11,11 +11,11 @@ jobs:
   build-test-matrix:
     name: ${{ matrix.jdk-distribution}}-${{ matrix.jdk-version }}-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         jdk-distribution: [temurin]
         jdk-version: [17]
     steps:

--- a/snapshots/src/main/script/createSnapshots.groovy
+++ b/snapshots/src/main/script/createSnapshots.groovy
@@ -28,10 +28,6 @@ WILDFLY_NAME = "wildfly"
 WILDFLY_REPOSITORY = "https://github.com/wildfly/wildfly"
 WILDFLY_REPOSITORY_PROPERTY = "wildfly.repository"
 WILDFLY_BRANCH_PROPERTY = "wildfly.branch"
-BOMS_NAME = "boms"
-BOMS_REPOSITORY = "https://github.com/wildfly/boms.git"
-BOMS_REPOSITORY_PROPERTY = "boms.repository"
-BOMS_BRANCH_PROPERTY = "boms.branch"
 TESTSUITE_VERSION = "EJB-CLIENT-TESTSUITE"
 MVN_BUILD_OPTIONS = "-DskipTests=true"
 
@@ -55,14 +51,12 @@ def wildFlyDir = new File(TARGET_DIR, WILDFLY_NAME)
 cloneProject(WILDFLY_REPOSITORY_PROPERTY, WILDFLY_BRANCH_PROPERTY, WILDFLY_REPOSITORY, WILDFLY_NAME)
 changeDependencyVersion(EJB_CLIENT_VERSION_NAME, TESTSUITE_VERSION, wildFlyDir)
 changeDependencyVersion(HTTP_CLIENT_VERSION_NAME, TESTSUITE_VERSION, wildFlyDir)
+setProjectVersion(TESTSUITE_VERSION, wildFlyDir)
+// testsuite/test-product-conf has hard-coded version value, that should not be overridden, but it is in previous command. So we need to skip this TS section in this WF build.
+// https://github.com/wildfly/wildfly/blob/main/testsuite/test-product-conf/pom.xml
+executeCmd("sed -i s|<module>test-product-conf</module>||g testsuite/pom.xml", null, wildFlyDir, false)
 buildProject(wildFlyDir, "-Dts.noSmoke")
 renameWildFlyBuildDirectory(getProjectVersion(wildFlyDir), wildFlyDir)
-
-def bomDir = new File(TARGET_DIR, BOMS_NAME)
-cloneProject(BOMS_REPOSITORY_PROPERTY, BOMS_BRANCH_PROPERTY, BOMS_REPOSITORY, BOMS_NAME)
-setProjectVersion(TESTSUITE_VERSION, bomDir)
-changeDependencyVersion("version.server", getProjectVersion(wildFlyDir), bomDir)
-buildProject(bomDir)
 
 
 def executeCmd(command, env, dir, verbose) {


### PR DESCRIPTION
Tracker: https://github.com/wildfly/ejb-client-testsuite/issues/64

This PR:

* Increase small timeout
* Remove windows jobs, because the script has never been run on Windows
* https://github.com/wildfly/boms project has been archived, because boms are now stored in WF repo directly. It's not necessary to build separate bom project, on the other hand, proper versions needs to be set to WF, because boms from it will be used in the rest of the TS.