### PR TITLE
Enforce alphabetical order of tests to increase stability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,7 @@
                     <version>${version.plugin.surefire}</version>
                     <configuration>
                         <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+                        <runOrder>alphabetical</runOrder>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Surefire alphabetical order is highly used in another WF TSs as well, see for example: https://github.com/wildfly/wildfly/blob/main/testsuite/integration/basic/pom.xml#L1470

