### PR TITLE
[WFLY-19909] Ignore tests affected by WFLY-19909

### DIFF
--- a/multinode/src/test/java/org/wildfly/ejbclient/testsuite/integration/multinode/twoclusters/ClientInvokingTwoClustersStatefulBeanTestCase.java
+++ b/multinode/src/test/java/org/wildfly/ejbclient/testsuite/integration/multinode/twoclusters/ClientInvokingTwoClustersStatefulBeanTestCase.java
@@ -27,6 +27,7 @@ import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Ignore;
 import org.wildfly.ejbclient.testsuite.integration.multinode.common.beans.whereami.WhereAmI;
 import org.wildfly.ejbclient.testsuite.integration.multinode.common.beans.whereami.WhereAmIStateful;
 import org.wildfly.ejbclient.testsuite.integration.multinode.environment.ContainerHelpers;
@@ -131,6 +132,7 @@ public class ClientInvokingTwoClustersStatefulBeanTestCase {
 
 
     @Test
+    @Ignore("https://issues.redhat.com/browse/WFLY-19909")
     public void testInvokingTwoClustersAlternately() throws Exception {
         final Properties propertiesCluster1 = new Properties();
         propertiesCluster1.put(Context.INITIAL_CONTEXT_FACTORY, WildFlyInitialContextFactory.class.getName());
@@ -170,6 +172,7 @@ public class ClientInvokingTwoClustersStatefulBeanTestCase {
     }
 
     @Test
+    @Ignore("https://issues.redhat.com/browse/WFLY-19909")
     public void testInvokingTwoClustersOneAfterAnother() throws Exception {
         logger.info("WILL NOW START INVOKING ON CLUSTER1");
         final Properties propertiesCluster1 = new Properties();

--- a/multinode/src/test/java/org/wildfly/ejbclient/testsuite/integration/multinode/twoclusters/ClientInvokingTwoClustersStatelessBeanTestCase.java
+++ b/multinode/src/test/java/org/wildfly/ejbclient/testsuite/integration/multinode/twoclusters/ClientInvokingTwoClustersStatelessBeanTestCase.java
@@ -27,6 +27,7 @@ import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Ignore;
 import org.wildfly.ejbclient.testsuite.integration.multinode.common.beans.whereami.WhereAmI;
 import org.wildfly.ejbclient.testsuite.integration.multinode.common.beans.whereami.WhereAmIStateless;
 import org.wildfly.ejbclient.testsuite.integration.multinode.environment.ContainerHelpers;
@@ -133,6 +134,7 @@ public class ClientInvokingTwoClustersStatelessBeanTestCase {
 
 
     @Test
+    @Ignore("https://issues.redhat.com/browse/WFLY-19909")
     public void testInvokingTwoClustersAlternately() throws Exception {
         final Properties propertiesCluster1 = new Properties();
         propertiesCluster1.put(Context.INITIAL_CONTEXT_FACTORY, WildFlyInitialContextFactory.class.getName());
@@ -170,6 +172,7 @@ public class ClientInvokingTwoClustersStatelessBeanTestCase {
     }
 
     @Test
+    @Ignore("https://issues.redhat.com/browse/WFLY-19909")
     public void testInvokingTwoClustersOneAfterAnother() throws Exception {
         logger.info("WILL NOW START INVOKING ON CLUSTER1");
         final Properties propertiesCluster1 = new Properties();

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
          and be sure that wf-core-launcher version works correctly with new arquillian-container -->
         <version.arquillian-container>5.1.0.Beta6</version.arquillian-container>
         <!-- the following version needs to be >= than version used in arquillian-container dependency -->
-        <version.wf.core>26.0.1.Final</version.wf.core>
+        <version.wf.core>25.0.2.Final</version.wf.core>
 
         <!-- MULTINODE -->
         <version.creaper>2.0.3</version.creaper>


### PR DESCRIPTION
I originally hoped that blocker jira https://issues.redhat.com/browse/WFLY-19909 would be fixed quickly, but related jira is open for 1 week without any feedback, so maybe that it's time to ignore tests in upstream to keep the stability here.

Latest release of wf arquillian common depends on wildfly core 25.0.2.Final:
```
[INFO] +- org.wildfly.arquillian:wildfly-arquillian-common:jar:5.1.0.Beta6:test
...
[INFO] |  |  \- org.wildfly.core:wildfly-server:jar:25.0.2.Final:test
```

Later versions of wf-core missed some logging methods, which leads to errors in multinode module:
```
2024-11-01T09:18:56.3360706Z java.lang.NoSuchMethodError: 'java.lang.Object org.jboss.logging.Logger.getMessageLogger(java.lang.invoke.MethodHandles$Lookup, java.lang.Class, java.lang.String)'
2024-11-01T09:18:56.3363106Z 	at org.jboss.as.protocol.logging.ProtocolLogger.<clinit>(ProtocolLogger.java:37)
...
2024-11-01T09:18:56.3426630Z 	at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:134)
2024-11-01T09:18:56.3427795Z 	at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:106)
2024-11-01T09:18:56.3428929Z 	at org.jboss.arquillian.core.impl.EventImpl.fire(EventImpl.java:62)
2024-11-01T09:18:56.3430648Z 	at org.jboss.arquillian.container.test.impl.client.container.ClientContainerController.start(ClientContainerController.java:87)
2024-11-01T09:18:56.3433224Z 	at org.wildfly.ejbclient.testsuite.integration.multinode.clusternodeselector.ClusterNodeSelectorTestCase.start(ClusterNodeSelectorTestCase.java:97)
```