### PR TITLE
Add JDK25 support

### DIFF
--- a/basic/pom-wildfly-client/pom.xml
+++ b/basic/pom-wildfly-client/pom.xml
@@ -639,10 +639,7 @@
         <profile>
             <id>security-manager-client</id>
             <activation>
-                <!--<activeByDefault>true</activeByDefault>-->
-                <!-- activeByDefault doesn't work for some reason - in that case the property
-                     overridings in this profile don't take effect.. so let's use a bit of a hack -->
-                <file><missing>THIS_FILE_WILL_NEVER_EXIST</missing></file>
+                <jdk>[,23]</jdk>
             </activation>
             <properties>
                 <security.manager.client.args>-Djava.security.manager

--- a/basic/pom.xml
+++ b/basic/pom.xml
@@ -477,10 +477,7 @@
         <profile>
             <id>security-manager-client</id>
             <activation>
-                <!--<activeByDefault>true</activeByDefault>-->
-                <!-- activeByDefault doesn't work for some reason - in that case the property
-                     overridings in this profile don't take effect.. so let's use a bit of a hack -->
-                <file><missing>THIS_FILE_WILL_NEVER_EXIST</missing></file>
+                <jdk>[,23]</jdk>
             </activation>
             <properties>
                 <security.manager.client.args>-Djava.security.manager


### PR DESCRIPTION
* Security manager has been removed in JDK24/JDK25: https://openjdk.org/jeps/486
> In JDK 24, we will:
> 
> Remove the ability to enable the Security Manager at startup,
> Remove the ability to install a custom Security Manager during run time, and
> Render the Security Manager API non-functional, in advance of removing the API in a future release.
